### PR TITLE
Fixes bad link to Tab Atkins's color spec draft.

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
 
   <section class="Section Section--feature Section--feature-color-manipulation">
     <h1 class="Section-title">Color Manipulation</h1>
-    <p class="Section-description">Straight from <a href="http://rawgithub.com/tabatkins/specs/master/css-color/Overview.html#modifying-colors">Tab Atkins's draft</a> for a future version of the spec.</p>
+    <p class="Section-description">Straight from <a href="http://rawgithub.com/tabatkins/specs/gh-pages/css-color/Overview.html#modifying-colors">Tab Atkins's draft</a> for a future version of the spec.</p>
     <figure class="Section-example">
       <pre class="Section-example-code">
 <b>a</b> {


### PR DESCRIPTION
It looks like there is no master branch anymore, so I linked to the only existing branch (gh-pages).
